### PR TITLE
Release 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,16 +13,16 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "specialized-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "specialized-dispatch"
 description = "A library for dispatching specialized versions of a function"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Omer Ozarslan"]
 edition = "2021"
 repository = "https://github.com/ozars/specialized-dispatch"


### PR DESCRIPTION
- Improve internal implementation of arguments.
- Accept and pass through `mut` before argument names.
- Add an example for a simplified serde-like use case.
- Add a note for the limitation related to lifetimes.